### PR TITLE
Fix out-of-order timestamp bug with ratelimit

### DIFF
--- a/packages/sqrl-redis-functions/src/lua/rateLimitFetchLua.ts
+++ b/packages/sqrl-redis-functions/src/lua/rateLimitFetchLua.ts
@@ -8,6 +8,7 @@ import { MockRedisDatabase } from "../mocks/MockRedisDatabase";
 export function rateLimitFetchLua() {
   // It is likely inefficient to update the expiry time on every ratelimit,
   // change, that could be optimized a lot.
+
   return (
     `
 local maxAmount = tonumber(ARGV[1])
@@ -27,6 +28,10 @@ if not current then
   lastRefill = at
 else
   tokens, lastRefill = struct.unpack("i8i8", current)
+
+  if lastRefill > at then
+    at = lastRefill
+  end
 end
 
 if take == 0 then
@@ -84,6 +89,9 @@ export function mockRateLimitFetch(
     lastRefill = at;
   } else {
     [tokens, lastRefill] = JSON.parse(current);
+    if (lastRefill > at) {
+      at = lastRefill;
+    }
   }
 
   if (take === 0) {

--- a/packages/sqrl-redis-functions/src/mocks/MockRedisService.ts
+++ b/packages/sqrl-redis-functions/src/mocks/MockRedisService.ts
@@ -20,7 +20,7 @@ export class MockRedisService implements RedisInterface, MockRedisDatabase {
   ): Promise<number> {
     return mockRateLimitFetch(
       this,
-      key.toString("utf-8"),
+      key.toString("hex"),
       opt.maxAmount,
       opt.take,
       opt.at,
@@ -37,7 +37,7 @@ export class MockRedisService implements RedisInterface, MockRedisDatabase {
   ): Promise<number> {
     return mockSessionize(
       this,
-      key.toString("utf-8"),
+      key.toString("hex"),
       opt.maxAmount,
       opt.take,
       opt.at,


### PR DESCRIPTION
# Problem

Out of order timestamps could trigger ratelimiter more often that it was specified for

# Solution

Don't allow out of order timestamps in ratelimit. If the new timestamp was before the last seen one, just move it up to the last seen one.

# Result

Added a test case which now passes