### PR TITLE
Disable code optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16653,9 +16653,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32260,9 +32260,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/websqrl/next.config.js
+++ b/websqrl/next.config.js
@@ -22,6 +22,10 @@ module.exports = {
       type: "asset/source",
     });
 
+    // Disable code optimization, SQRL uses function names
+    assert(config.optimization);
+    config.optimization.minimize = false
+
     const oneOfRule = config.module.rules.find(
       /** @returns {rule is import('webpack').RuleSetRule} */
       (rule) => typeof rule === "object" && !!rule.oneOf


### PR DESCRIPTION
# Problem

SQRL uses the function names to register functions.

# Solution

Perhaps we should pass them in as arguments, but that can be a later discussion. For now disable the minification.

# Result

WebSQRL should work on vercel again