### PR TITLE
Text functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18735,7 +18735,8 @@
         "sprintf-js": "^1.1.2",
         "sqrl": "^0.6.9",
         "sqrl-jsonpath": "^0.6.9",
-        "sqrl-redis-functions": "^0.6.9"
+        "sqrl-redis-functions": "^0.6.9",
+        "sqrl-text-functions": "^0.6.9"
       },
       "devDependencies": {
         "@types/node": "^18.0.0",
@@ -32643,6 +32644,7 @@
         "sqrl": "^0.6.9",
         "sqrl-jsonpath": "^0.6.9",
         "sqrl-redis-functions": "^0.6.9",
+        "sqrl-text-functions": "^0.6.9",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.8.4"

--- a/packages/sqrl-text-functions/package.json
+++ b/packages/sqrl-text-functions/package.json
@@ -23,6 +23,10 @@
     "lib"
   ],
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./web": "./lib/web.js"
+  },
   "typings": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf lib && rimraf coverage",

--- a/packages/sqrl-text-functions/src/TextFunctionsConfig.ts
+++ b/packages/sqrl-text-functions/src/TextFunctionsConfig.ts
@@ -1,0 +1,3 @@
+export interface TextFunctionsConfig {
+  builtinRegExp?: boolean;
+}

--- a/packages/sqrl-text-functions/src/index.ts
+++ b/packages/sqrl-text-functions/src/index.ts
@@ -12,9 +12,14 @@ import {
   sqrlInvariant,
 } from "sqrl";
 import { registerPatternFunctions } from "./PatternFunctions";
-import { InProcessPatternService } from "./InProcessPatternService";
+import { InProcessPatternService, CreateRegExp } from "./InProcessPatternService";
 import { SimHash } from "simhash-js";
 import { createHash } from "crypto";
+import * as RE2 from "re2";
+
+interface TextFunctionsConfig {
+  'builtinRegExp'?: boolean
+}
 
 export function register(instance: Instance) {
   const jsSimhash = new SimHash();
@@ -128,5 +133,13 @@ export function register(instance: Instance) {
     }
   );
 
-  registerPatternFunctions(instance, new InProcessPatternService());
+  const config: TextFunctionsConfig = instance.getConfig()['sqrl-text-functions'];
+
+  let createRegExp: CreateRegExp;
+  if (config.builtinRegExp) {
+    createRegExp = (source, flags) => new RegExp(source, flags);
+  } else {
+    createRegExp = (source, flags) => new RE2(source, flags);
+  }
+  registerPatternFunctions(instance, new InProcessPatternService(createRegExp));
 }

--- a/packages/sqrl-text-functions/src/registerWithEngine.ts
+++ b/packages/sqrl-text-functions/src/registerWithEngine.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2019 Twitter, Inc.
+ * Licensed under the Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {
+  AT,
+  Instance,
+  CompileState,
+  Ast,
+  AstBuilder,
+  sqrlInvariant,
+} from "sqrl";
+import { registerPatternFunctions } from "./PatternFunctions";
+import {
+  InProcessPatternService,
+  CreateRegExp,
+} from "./InProcessPatternService";
+import { SimHash } from "simhash-js";
+import { createHash } from "crypto";
+
+export function registerWithEngine(
+  instance: Instance,
+  createRegExp: CreateRegExp
+) {
+  const jsSimhash = new SimHash();
+
+  instance.registerSync(
+    function sha256(data: Buffer | string): string {
+      const hasher = createHash("sha256");
+      if (data instanceof Buffer) {
+        hasher.update(data);
+      } else {
+        hasher.update(data, "utf8");
+      }
+      return hasher.digest("hex");
+    },
+    {
+      args: [AT.any],
+      pure: true,
+      argstring: "value",
+      docstring: "Returns the sha256 hash of the given value as hex",
+    }
+  );
+
+  instance.registerSync(
+    function simhash(text: string) {
+      const hashHex: string = jsSimhash.hash(text).toString(16);
+      return hashHex.padStart(8, "0");
+    },
+    {
+      args: [AT.any.string],
+      argstring: "text",
+      docstring: "Return the simhash of the given text",
+    }
+  );
+
+  instance.registerSync(
+    function _charGrams(string, gramSize) {
+      const grams = [];
+      for (let i = 0; i <= string.length - gramSize; i++) {
+        grams.push(string.substr(i, gramSize));
+      }
+      return grams;
+    },
+    {
+      args: [AT.any.string, AT.constant.number],
+    }
+  );
+  instance.registerTransform(
+    function charGrams(state: CompileState, ast): Ast {
+      const sizeAst = ast.args[1];
+      sqrlInvariant(
+        ast,
+        sizeAst.type === "constant" && sizeAst.value > 0,
+        "charGrams size must be > 0"
+      );
+      return AstBuilder.call("_charGrams", ast.args);
+    },
+    {
+      args: [AT.any, AT.constant.number],
+      argstring: "text, size",
+      docstring: "Returns all the chargrams of a given size from the text",
+    }
+  );
+
+  instance.registerSync(
+    function regexMatch(state, regex, string) {
+      return string.match(new RegExp(regex, "g"));
+    },
+    {
+      args: [AT.state, AT.any.string, AT.any.string],
+      argstring: "regex, string",
+      docstring:
+        "Returns the matches of the given regular expression against the string",
+    }
+  );
+
+  instance.registerSync(
+    function regexTest(state, regex, string) {
+      return new RegExp(regex, "g").test(string);
+    },
+    {
+      args: [AT.state, AT.any.string, AT.any.string],
+      argstring: "regex, string",
+      docstring:
+        "Returns true if the given regular expression matches the string",
+    }
+  );
+
+  instance.registerSync(
+    function regexReplace(state, regex, replacement, string) {
+      return string.replace(new RegExp(regex, "g"), replacement);
+    },
+    {
+      args: [AT.state, AT.any.string, AT.any.string, AT.any],
+      argstring: "regex, replacement, string",
+      docstring:
+        "Replaces each match of the given regular expression in the string",
+    }
+  );
+
+  const RE_EMAIL = new RegExp("[^\\d\\w]+", "ig");
+
+  instance.registerSync(
+    function normalizeEmail(state, email: string) {
+      const [handle, domain] = email.toLowerCase().split("@", 2);
+      return handle.split("+")[0].replace(RE_EMAIL, "") + "@" + domain;
+    },
+    {
+      args: [AT.state, AT.any.string],
+      argstring: "email",
+      docstring: "Returns the normalized form of the given email address",
+    }
+  );
+
+  registerPatternFunctions(instance, new InProcessPatternService(createRegExp));
+}

--- a/packages/sqrl-text-functions/src/web.ts
+++ b/packages/sqrl-text-functions/src/web.ts
@@ -4,21 +4,16 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import { Instance } from "sqrl";
-import { CreateRegExp } from "./InProcessPatternService";
 import { registerWithEngine } from "./registerWithEngine";
-import * as RE2 from "re2";
 import { TextFunctionsConfig } from "./TextFunctionsConfig";
 
 export function register(instance: Instance) {
   const config: TextFunctionsConfig =
     instance.getConfig()["sqrl-text-functions"] || {};
 
-  let createRegExp: CreateRegExp;
-  if (config.builtinRegExp) {
-    createRegExp = (source, flags) => new RegExp(source, flags);
-  } else {
-    createRegExp = (source, flags) => new RE2(source, flags);
+  if (!config.builtinRegExp) {
+    throw new Error("Only builtin regexp support is available on web.");
   }
-
+  const createRegExp = (source, flags) => new RegExp(source, flags);
   registerWithEngine(instance, createRegExp);
 }

--- a/websqrl/next.config.js
+++ b/websqrl/next.config.js
@@ -14,6 +14,7 @@ module.exports = {
     config.resolve.fallback = {
       // the require for this module is wrapped in a try/catch, so it can fail without causing issues
       "sqrl-test-utils": false,
+      "re2": false,
     };
 
     assert(config.module?.rules);

--- a/websqrl/package.json
+++ b/websqrl/package.json
@@ -23,7 +23,8 @@
     "sprintf-js": "^1.1.2",
     "sqrl": "^0.6.9",
     "sqrl-jsonpath": "^0.6.9",
-    "sqrl-redis-functions": "^0.6.9"
+    "sqrl-redis-functions": "^0.6.9",
+    "sqrl-text-functions": "^0.6.9"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/websqrl/workers/compile.worker.ts
+++ b/websqrl/workers/compile.worker.ts
@@ -1,7 +1,7 @@
 import * as SQRL from "sqrl";
 import * as sqrlJsonPath from "sqrl-jsonpath";
 import * as sqrlRedisFunctions from "sqrl-redis-functions";
-import * as sqrlTextFunctions from "sqrl-text-functions";
+import * as sqrlTextFunctions from "sqrl-text-functions/web";
 import { Request, Response, WikiEvent, LogEntry } from "../src/types";
 import { Execution, AT } from "sqrl";
 import { invariant } from "../src/invariant";
@@ -24,9 +24,9 @@ async function buildInstance() {
   const instance = SQRL.createInstance({
     config: {
       "state.allow-in-memory": true,
-      'sqrl-text-functions': {
+      "sqrl-text-functions": {
         builtinRegExp: true,
-      }
+      },
     },
   });
   await instance.importFromPackage("sqrl-jsonpath", sqrlJsonPath);

--- a/websqrl/workers/compile.worker.ts
+++ b/websqrl/workers/compile.worker.ts
@@ -1,6 +1,7 @@
 import * as SQRL from "sqrl";
 import * as sqrlJsonPath from "sqrl-jsonpath";
 import * as sqrlRedisFunctions from "sqrl-redis-functions";
+import * as sqrlTextFunctions from "sqrl-text-functions";
 import { Request, Response, WikiEvent, LogEntry } from "../src/types";
 import { Execution, AT } from "sqrl";
 import { invariant } from "../src/invariant";
@@ -23,10 +24,14 @@ async function buildInstance() {
   const instance = SQRL.createInstance({
     config: {
       "state.allow-in-memory": true,
+      'sqrl-text-functions': {
+        builtinRegExp: true,
+      }
     },
   });
   await instance.importFromPackage("sqrl-jsonpath", sqrlJsonPath);
   await instance.importFromPackage("sqrl-redis-functions", sqrlRedisFunctions);
+  await instance.importFromPackage("sqrl-text-functions", sqrlTextFunctions);
 
   instance.registerStatement(
     "SqrlLogStatements",


### PR DESCRIPTION
# Problem

Sample rules for Twitter spam protection would be better with `sqrl-text-functions`.

# Solution

Include the module. It will require a little bit of magic because the code currently uses `fs` and `re2` which are not available in browser.

# Result

`simhash()` function is available in `websqrl`