### PR TITLE
Added a route for health check

### DIFF
--- a/packages/sqrl-cli/src/SqrlServer.ts
+++ b/packages/sqrl-cli/src/SqrlServer.ts
@@ -115,7 +115,7 @@ async function deleteRoute(
 
 export function createSqrlServer(ctx: Context, executable: Executable): Server {
   const router = dispatch()
-    .dispatch('/', '*', (req, res, { params, query }) => send(res, 200, "Hello"))
+    .dispatch('/health', '*', (req, res, { params, query }) => send(res, 200, "Hello"))
     .dispatch("/run", ["POST"], (req, res) => run(ctx, executable, req, res))
     .dispatch("/delete", ["POST"], (req, res) => deleteRoute(ctx, req, res))
     .otherwise(async (req, res) => {

--- a/packages/sqrl-cli/src/SqrlServer.ts
+++ b/packages/sqrl-cli/src/SqrlServer.ts
@@ -115,7 +115,7 @@ async function deleteRoute(
 
 export function createSqrlServer(ctx: Context, executable: Executable): Server {
   const router = dispatch()
-    .dispatch('/health', '*', (req, res, { params, query }) => send(res, 200, "Hello"))
+    .dispatch('/health', ["GET"], (req, res, { params, query }) => send(res, 200, "Healthy"))
     .dispatch("/run", ["POST"], (req, res) => run(ctx, executable, req, res))
     .dispatch("/delete", ["POST"], (req, res) => deleteRoute(ctx, req, res))
     .otherwise(async (req, res) => {

--- a/packages/sqrl-cli/src/SqrlServer.ts
+++ b/packages/sqrl-cli/src/SqrlServer.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import micro, { createError, json as microJson } from "micro";
+import micro, { createError, send, json as microJson } from "micro";
 import * as microQuery from "micro-query";
 // tslint:disable-next-line:no-submodule-imports (it is the documented suggestion)
 import * as dispatch from "micro-route/dispatch";
@@ -115,6 +115,7 @@ async function deleteRoute(
 
 export function createSqrlServer(ctx: Context, executable: Executable): Server {
   const router = dispatch()
+    .dispatch('/', '*', (req, res, { params, query }) => send(res, 200, "Hello"))
     .dispatch("/run", ["POST"], (req, res) => run(ctx, executable, req, res))
     .dispatch("/delete", ["POST"], (req, res) => deleteRoute(ctx, req, res))
     .otherwise(async (req, res) => {


### PR DESCRIPTION
# Problem

In Kubernetes running docker containers typically need a readiness and health checks to make sure the container is running/ready

# Solution

Describe the modifications you've done.
Added a path for /health that just returns 200 so the container can run in K8s.

# Result

This will always return a passing health check so long as its running. Note that to truly follow k8s semantics we would probably want a seperate readiness check to pass (for instance once we've established a connection to redis), versus liveness which just checks that the service is alive. LMK if this is important enough to revise