### PR TITLE
Assorted UI updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7079,10 +7079,22 @@
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
+    "node_modules/@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.0.tgz",
+      "integrity": "sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.14",
@@ -9491,8 +9503,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/csv-stringify": {
       "version": "5.6.5",
@@ -11334,6 +11345,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -12985,6 +13001,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ioredis": {
@@ -15506,6 +15530,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jsxstyle": {
+      "version": "0.0.0-canary-20221208194337",
+      "resolved": "https://registry.npmjs.org/jsxstyle/-/jsxstyle-0.0.0-canary-20221208194337.tgz",
+      "integrity": "sha512-TZIj1jmBsPf8P3gz7AS8JVwWEvsU2E1t/oVsmedWh3SCPqgtsOebvg0Bu99wysJRmdflIKn2P/MKoPhF6WeG5w==",
+      "dependencies": {
+        "@babel/core": "^7.17.9",
+        "@babel/generator": "^7.17.9",
+        "@babel/parser": "^7.17.9",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "csstype": "^3.0.11",
+        "invariant": "^2.2.4",
+        "memfs": "^3.4.1"
+      }
+    },
     "node_modules/just-diff": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-5.1.1.tgz",
@@ -16187,6 +16226,17 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
+      "integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
+      "dependencies": {
+        "fs-monkey": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/meow": {
@@ -24397,6 +24447,7 @@
       "version": "0.1.0",
       "dependencies": {
         "date-fns": "^2.29.3",
+        "jsxstyle": "canary",
         "monaco-editor": "^0.34.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "next": "^13.0.4",
@@ -24411,12 +24462,15 @@
         "sqrl-text-functions": "^0.6.9"
       },
       "devDependencies": {
-        "@types/react": "^18.0.25"
+        "@types/react": "^18.0.25",
+        "@types/sprintf-js": "^1.1.2",
+        "@types/webpack-env": "^1.18.0"
       }
     },
     "websqrl/node_modules/sprintf-js": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     }
   },
   "dependencies": {
@@ -29744,10 +29798,22 @@
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
+    "@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/webpack-env": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.0.tgz",
+      "integrity": "sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.14",
@@ -31585,8 +31651,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "csv-stringify": {
       "version": "5.6.5",
@@ -32946,6 +33011,11 @@
         "minipass": "^3.0.0"
       }
     },
+    "fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -34171,6 +34241,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "ioredis": {
       "version": "4.28.5",
@@ -36080,6 +36158,21 @@
         "object.assign": "^4.1.3"
       }
     },
+    "jsxstyle": {
+      "version": "0.0.0-canary-20221208194337",
+      "resolved": "https://registry.npmjs.org/jsxstyle/-/jsxstyle-0.0.0-canary-20221208194337.tgz",
+      "integrity": "sha512-TZIj1jmBsPf8P3gz7AS8JVwWEvsU2E1t/oVsmedWh3SCPqgtsOebvg0Bu99wysJRmdflIKn2P/MKoPhF6WeG5w==",
+      "requires": {
+        "@babel/core": "^7.17.9",
+        "@babel/generator": "^7.17.9",
+        "@babel/parser": "^7.17.9",
+        "@babel/traverse": "^7.17.9",
+        "@babel/types": "^7.17.0",
+        "csstype": "^3.0.11",
+        "invariant": "^2.2.4",
+        "memfs": "^3.4.1"
+      }
+    },
     "just-diff": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-5.1.1.tgz",
@@ -36616,6 +36709,14 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
       "integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw=="
+    },
+    "memfs": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
+      "integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
+      "requires": {
+        "fs-monkey": "^1.0.3"
+      }
     },
     "meow": {
       "version": "8.1.2",
@@ -42393,7 +42494,10 @@
       "version": "file:websqrl",
       "requires": {
         "@types/react": "^18.0.25",
+        "@types/sprintf-js": "^1.1.2",
+        "@types/webpack-env": "^1.18.0",
         "date-fns": "^2.29.3",
+        "jsxstyle": "canary",
         "monaco-editor": "^0.34.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "next": "^13.0.4",
@@ -42409,7 +42513,9 @@
       },
       "dependencies": {
         "sprintf-js": {
-          "version": "1.1.2"
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         }
       }
     },

--- a/packages/sqrl/src/api/execute.ts
+++ b/packages/sqrl/src/api/execute.ts
@@ -59,9 +59,10 @@ export interface ExecutableOptions {
   instance: Instance;
 }
 
-export interface FeatureMap {
-  [feature: string]: any;
-}
+export type FeatureMap<T extends string = string> = {
+  // TODO(meyer) any --> unknown
+  [key in T]: any;
+};
 
 export interface FunctionInfo {
   name: string;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,15 +13,14 @@
     "strict": true,
     "outDir": "./lib",
     "preserveConstEnums": true,
-    "removeComments": true,
-    "inlineSourceMap": false,
-    "typeRoots": ["./node_modules/@types"],
+    "sourceMap": false,
     "experimentalDecorators": true,
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "stripInternal": true
   }
 }

--- a/websqrl/TweetManipulator.ts
+++ b/websqrl/TweetManipulator.ts
@@ -6,18 +6,27 @@
 
 import { SimpleManipulator, WhenCause } from "sqrl";
 
-export interface TweetResult {
-  blocked: boolean;
-  blockedCause?: WhenCause;
+interface BlockedTweetResult {
+  blocked: true;
+  blockedCause: WhenCause;
 }
+
+interface UnblockedTweetResult {
+  blocked: false;
+}
+
+export type TweetResult = BlockedTweetResult | UnblockedTweetResult;
+
 export class TweetManipulator extends SimpleManipulator {
   private result: TweetResult = {
     blocked: false,
   };
 
   blockTweet(cause: WhenCause) {
-    this.result.blocked = true;
-    this.result.blockedCause = cause;
+    this.result = {
+      blocked: true,
+      blockedCause: cause,
+    };
   }
 
   getResult() {

--- a/websqrl/components/Container.tsx
+++ b/websqrl/components/Container.tsx
@@ -1,0 +1,19 @@
+import { Box } from "jsxstyle";
+import { styleConstants } from "../src/constants";
+
+interface ContainerProps {
+  children: React.ReactNode;
+}
+
+export const Container: React.FC<ContainerProps> = ({ children }) => (
+  <Box
+    backgroundColor={styleConstants.insetBackground}
+    borderRadius={styleConstants.containerRadius}
+    border="1px solid"
+    borderColor={styleConstants.containerOutlineColor}
+    backgroundClip="padding-box"
+    padding="7px 10px"
+  >
+    {children}
+  </Box>
+);

--- a/websqrl/components/TweetStory.tsx
+++ b/websqrl/components/TweetStory.tsx
@@ -1,0 +1,91 @@
+import { Block, Col, Inline, Row } from "jsxstyle";
+import { useMemo } from "react";
+import { sprintf } from "sprintf-js";
+import { styleConstants } from "../src/constants";
+import type { Result } from "../src/types";
+
+export const TWEET_FETCH_FEATURES = [
+  "AuthorUsername",
+  "AuthorProfileImageUrl",
+  "TweetText",
+  "TweetId",
+  "TweetDate",
+] as const;
+export type TweetFetchFeature = typeof TWEET_FETCH_FEATURES[number];
+
+type TweetStoryProps = Omit<Result<TweetFetchFeature>, "type">;
+
+export const TweetStory: React.FC<TweetStoryProps> = ({
+  features,
+  result,
+  logs,
+}) => {
+  const userUrl = `https://twitter.com/${features.AuthorUsername}`;
+  const tweetUrl = `https://twitter.com/${features.AuthorUsername}/status/${features.TweetId}`;
+
+  const messages = [];
+  for (const msg of logs) {
+    messages.push(sprintf(msg.format, ...msg.args));
+  }
+
+  return (
+    <Col gap={10}>
+      <Row gap={6}>
+        <Block
+          backgroundImage={`url("${features.AuthorProfileImageUrl}")`}
+          backgroundPosition="center center"
+          backgroundSize="contain"
+          height={40}
+          width={40}
+          borderRadius={4}
+        />
+
+        <a target="_blank" href={userUrl}>
+          @{features.AuthorUsername}
+        </a>
+        <Inline color={styleConstants.secondary}>
+          (
+          <a href={tweetUrl} target="_blank">
+            {features.TweetDate}
+          </a>
+          )
+        </Inline>
+      </Row>
+
+      <Block
+        component="blockquote"
+        borderLeft="2px solid"
+        padding="4px 10px"
+        borderColor={styleConstants.secondary}
+      >
+        {features.TweetText}
+      </Block>
+
+      {result.blocked && (
+        <Block color={styleConstants.secondary}>
+          <Block>Rules fired</Block>
+          <Block component="ul" listStyle="inside">
+            {result.blockedCause.firedRules.map((rule) => (
+              <li key={rule.name}>
+                {rule.name}
+                {rule.reason ? ": " + rule.reason : null}
+              </li>
+            ))}
+          </Block>
+        </Block>
+      )}
+
+      <Block color={styleConstants.secondary}>
+        <Block>
+          {messages.length || "No"} logged message
+          {messages.length === 1 ? "" : "s"}
+        </Block>
+        <Block component="ul" listStyle="inside">
+          {messages.map((message, index) => (
+            <li key={index}>{message}</li>
+          ))}
+        </Block>
+      </Block>
+    </Col>
+  );
+};

--- a/websqrl/components/WikipediaEventStory.tsx
+++ b/websqrl/components/WikipediaEventStory.tsx
@@ -1,0 +1,16 @@
+import { Block } from "jsxstyle";
+import type { Result } from "../src/types";
+
+export const WIKIPEDIA_FETCH_FEATURES = [
+  "AuthorUsername",
+  "TweetText",
+  "TweetId",
+  "TweetDate",
+] as const;
+export type WikipediaFetchFeature = typeof WIKIPEDIA_FETCH_FEATURES[number];
+
+type WikipediaEventStoryProps = Omit<Result<WikipediaFetchFeature>, "type">;
+
+export const WikipediaEventStory: React.FC<WikipediaEventStoryProps> = () => {
+  return <Block>hello!</Block>;
+};

--- a/websqrl/package.json
+++ b/websqrl/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "date-fns": "^2.29.3",
+    "jsxstyle": "canary",
     "monaco-editor": "^0.34.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "next": "^13.0.4",
@@ -23,7 +24,9 @@
     "sqrl-text-functions": "^0.6.9"
   },
   "devDependencies": {
-    "@types/react": "^18.0.25"
+    "@types/react": "^18.0.25",
+    "@types/sprintf-js": "^1.1.2",
+    "@types/webpack-env": "^1.18.0"
   },
   "repository": "https://github.com/sqrl-lang/sqrl/tree/main/websqrl"
 }

--- a/websqrl/pages/twitter.tsx
+++ b/websqrl/pages/twitter.tsx
@@ -1,12 +1,23 @@
+import Head from "next/head";
 import { StreamPage } from "../components/StreamPage";
+import { TWEET_FETCH_FEATURES, TweetStory } from "../components/TweetStory";
 import sampleCode from "../src/twitter-sample.sqrl";
 
 export default function TwitterPage() {
   return (
-    <StreamPage
-      urlPrefix="https://sqrl-twitter-stream.s3.amazonaws.com/v1/"
-      extractDate={(payload) => new Date(payload.dt)}
-      sampleCode={sampleCode}
-    ></StreamPage>
+    <>
+      <Head>
+        <title>SQRL Twitter Demo</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <StreamPage
+        urlPrefix="https://sqrl-twitter-stream.s3.amazonaws.com/v1/"
+        extractDate={(payload) => new Date(payload.dt)}
+        sampleCode={sampleCode}
+        storyComponent={TweetStory}
+        fetchFeatures={TWEET_FETCH_FEATURES}
+        shouldLogResult={(result) => result.result.blocked}
+      />
+    </>
   );
 }

--- a/websqrl/pages/wikipedia.tsx
+++ b/websqrl/pages/wikipedia.tsx
@@ -1,12 +1,26 @@
+import Head from "next/head";
 import { StreamPage } from "../components/StreamPage";
+import {
+  WikipediaEventStory,
+  WIKIPEDIA_FETCH_FEATURES,
+} from "../components/WikipediaEventStory";
 import sampleCode from "../src/wikipedia-sample.sqrl";
 
-export default function TwitterPage() {
+export default function WikipediaPage() {
   return (
-    <StreamPage
-      urlPrefix="https://sqrl-aws-diffs.s3.amazonaws.com/v1/en.wikipedia.org/"
-      extractDate={(payload) => new Date(payload.meta.dt)}
-      sampleCode={sampleCode}
-    ></StreamPage>
+    <>
+      <Head>
+        <title>SQRL Wikipedia Demo</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <StreamPage
+        urlPrefix="https://sqrl-aws-diffs.s3.amazonaws.com/v1/en.wikipedia.org/"
+        extractDate={(payload) => new Date(payload.meta.dt)}
+        sampleCode={sampleCode}
+        storyComponent={WikipediaEventStory}
+        fetchFeatures={WIKIPEDIA_FETCH_FEATURES}
+        shouldLogResult={(result) => result.result.blocked}
+      />
+    </>
   );
 }

--- a/websqrl/src/MonacoEditor.tsx
+++ b/websqrl/src/MonacoEditor.tsx
@@ -14,6 +14,7 @@ export interface MonacoEditorProps {
   theme?: string;
   value: string;
   style?: React.CSSProperties;
+  markers?: Omit<EditorApi.editor.IMarkerData, "relatedInformation">[];
 }
 
 export const MonacoEditor: React.FC<MonacoEditorProps> = ({
@@ -23,6 +24,7 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
   theme = "vs-dark",
   value,
   style,
+  markers,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const monacoEditorObj = useMonacoEditor();
@@ -30,7 +32,20 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
 
   useEffect(() => {
     editorRef.current?.updateOptions({ theme });
-  }, [theme]);
+  }, [editorRef.current, theme]);
+
+  useEffect(() => {
+    if (!editorRef.current || monacoEditorObj.state !== "success") return;
+
+    const model = editorRef.current.getModel();
+    if (!model) return;
+
+    monacoEditorObj.value.editor.setModelMarkers(
+      model,
+      "monaco editor react",
+      markers || []
+    );
+  }, [editorRef.current, monacoEditorObj.state, markers]);
 
   useEffect(() => {
     if (monacoEditorObj.state !== "success") return;
@@ -48,13 +63,13 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
     );
 
     const editor = monacoEditor.editor.create(containerRef.current, {
-      ...options,
-      extraEditorClassName: className,
-      language: "cpp",
-      scrollBeyondLastLine: false,
+      scrollBeyondLastLine: true,
       minimap: {
         enabled: true,
       },
+      ...options,
+      extraEditorClassName: className,
+      language: "cpp",
       model,
       theme,
     });

--- a/websqrl/src/constants.ts
+++ b/websqrl/src/constants.ts
@@ -1,0 +1,28 @@
+import { EXPERIMENTAL_makeCustomProperties } from "jsxstyle";
+
+// `makeCustomProperties` generates a JS object of CSS variables that can be used in place of style values.
+// Variable values can be optionally overridden for each style variant.
+export const styleConstants = EXPERIMENTAL_makeCustomProperties({
+  boxShadowColor: "#333",
+  pageForeground: "#000",
+  secondary: "#888",
+  pageBackground: "#EEE",
+  insetBackground: "#FFF",
+  containerOutlineColor: "rgba(0,0,0,0.15)",
+  containerRadius: "6px",
+})
+  .addVariant("darkMode", {
+    mediaQuery: "screen and (prefers-color-scheme: dark)",
+    boxShadowColor: "#AAA",
+    pageForeground: "#FFF",
+    secondary: "#AAA",
+    pageBackground: "#000",
+    insetBackground: "#333",
+    containerOutlineColor: "rgba(255,255,255,0.2)",
+  })
+  .build();
+
+// if we're in dev mode, we'll need to dispose of accumulated styles when this module is hot reloaded
+if (process.env.NODE_ENV !== "production") {
+  module.hot?.dispose(styleConstants.reset);
+}

--- a/websqrl/src/twitter-sample.sqrl
+++ b/websqrl/src/twitter-sample.sqrl
@@ -1,27 +1,25 @@
 LET EventData := input();
 LET SqrlClock := TweetDate;
 
-LET Text := jsonValue(EventData, '$.data.text');
+LET TweetText := jsonValue(EventData, '$.data.text');
 LET AuthorId := jsonValue(EventData, '$.data.author_id');
 LET TweetId := jsonValue(EventData, '$.data.id');
 LET TweetDate := jsonValue(EventData, '$.data.created_at');
 LET Users := jsonValue(EventData, '$.includes.users');
-LET UserData := first([It for It in Users where jsonValue(It, "$.id") = AuthorId]);
-LET User := entity("User", jsonValue(UserData, "$.username"));
-LET UserCreatedAt := jsonValue(UserData, "$.created_at");
-LET UserName := jsonValue(UserData, "$.name");
+LET AuthorUserData := first([It for It in Users where jsonValue(It, "$.id") = AuthorId]);
+LET AuthorUsername := entity("User", jsonValue(AuthorUserData, "$.username"));
+LET AuthorCreatedAt := jsonValue(AuthorUserData, "$.created_at");
+LET AuthorName := jsonValue(AuthorUserData, "$.name");
+LET AuthorProfileImageUrl := jsonValue(AuthorUserData, "$.profile_image_url");
 
-LET Simhash := simhash(Text);
+LET TweetTextSimhash := simhash(TweetText);
 
-LET TweetsByUser := count(BY User TOTAL);
-LET CountBySimhash := count(BY Simhash LAST 1 HOUR);
-LET UsersBySimhash := countUnique(User BY Simhash LAST HOUR);
-
+LET TweetsByUser := count(BY AuthorUsername TOTAL);
+LET CountBySimhash := count(BY TweetTextSimhash LAST 1 HOUR);
+LET UsersBySimhash := countUnique(AuthorUsername BY TweetTextSimhash LAST HOUR);
 
 LET Global := true;
 LET TotalTweets := count(BY Global);
-LET ShouldLog := rateLimit(BY Global EVERY 5 SECONDS) OR
-    CountBySimhash>1 OR UsersBySimhash>1;
 
 CREATE RULE SimilarTweetText WHERE CountBySimhash>1 WITH REASON
     "Seen multiple tweets with similar text";

--- a/websqrl/src/types.ts
+++ b/websqrl/src/types.ts
@@ -9,21 +9,30 @@ export interface CompileRequest {
   type: "compile";
   source: string;
 }
-export interface EventRequest {
+export interface EventRequest<T extends string> {
   type: "event";
   event: EventData;
-  requestFeatures: string[];
+  requestFeatures: readonly T[];
 }
-export type Request = CompileRequest | EventRequest;
+export type Request<T extends string> = CompileRequest | EventRequest<T>;
 
 export interface CompileOkay {
   type: "compileOkay";
   source: string;
 }
+
+interface Location {
+  column: number;
+  line: number;
+  offset: number;
+}
+
 export interface CompileError {
   type: "compileError";
+  stack: string;
   message: string;
   source: string;
+  location: Record<"start" | "end", Location> | undefined;
 }
 export interface RuntimeError {
   type: "runtimeError";
@@ -34,15 +43,19 @@ export interface LogEntry {
   format: string;
   args: any[];
 }
-export interface Result {
+export interface Result<T extends string> {
   type: "result";
   logs: Array<LogEntry>;
   result: TweetResult;
-  features: FeatureMap;
+  features: FeatureMap<T>;
   source: string;
 }
 export interface Render {
   type: "render";
   buffer: Uint8Array;
 }
-export type Response = CompileOkay | CompileError | RuntimeError | Result;
+export type Response<T extends string> =
+  | CompileOkay
+  | CompileError
+  | RuntimeError
+  | Result<T>;

--- a/websqrl/styles/globals.css
+++ b/websqrl/styles/globals.css
@@ -4,8 +4,16 @@ body {
   margin: 0;
   width: 100%;
   height: 100%;
+}
+
+html {
+  font-size: 62.5%;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+}
+
+body {
+  font-size: 1.4rem;
 }
 
 #__next {
@@ -18,5 +26,14 @@ a {
 }
 
 * {
+  font-size: inherit;
+  line-height: 1.4;
   box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+ul,
+ol {
+  list-style: none;
 }

--- a/websqrl/tsconfig.json
+++ b/websqrl/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "useDefineForClassFields": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -16,5 +18,34 @@
     "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "references": [
+    {
+      "path": "../packages/sqrl"
+    },
+    {
+      "path": "../packages/sqrl-cli"
+    },
+    {
+      "path": "../packages/sqrl-cli-functions"
+    },
+    {
+      "path": "../packages/sqrl-common"
+    },
+    {
+      "path": "../packages/sqrl-jsonpath"
+    },
+    {
+      "path": "../packages/sqrl-load-functions"
+    },
+    {
+      "path": "../packages/sqrl-redis-functions"
+    },
+    {
+      "path": "../packages/sqrl-test-utils"
+    },
+    {
+      "path": "../packages/sqrl-text-functions"
+    }
+  ],
+  "exclude": ["node_modules", "**/*.worker.ts"]
 }

--- a/websqrl/tsconfig.worker.json
+++ b/websqrl/tsconfig.worker.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.worker.ts"],
+  "compilerOptions": {
+    "lib": ["WebWorker"]
+  }
+}


### PR DESCRIPTION
# Problem

WebSQRL UI needs some love.

# Solution

I made a variety of changes:

- **dark mode support**. We can add a manual toggle too if we want.
- **small screen support**. The editor flips from row to column on narrow screens.
- **error marker support** in the editor. SQRL compile errors will now have their location highlighted once compilation is done. This closes #13.
- **minor tweet formatting updates**. The general layout is the same but I updated spacing and colours. Tweets are also now logged reverse-chronologically to match the Twitter UI. This closes #12 (though there is obviously more work to do).
  - One open question: should we load avatars in the tweet view?

# Result

<img width="1381" alt="Screenshot of the updated SQRL UI" src="https://user-images.githubusercontent.com/13781/206926048-d01bf015-c95b-499c-8ca5-2f99b12f1a7f.png">

Apologies for the chunky revision. Future revisions should be a bit more succinct and focused as we eliminate the low-hanging fruit.