### PR TITLE
Add a `paths` entry to websqrl’s tsconfig file

### DIFF
--- a/websqrl/tsconfig.json
+++ b/websqrl/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -15,7 +14,18 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "sqrl": ["../packages/sqrl"],
+      "sqrl-cli": ["../packages/sqrl-cli"],
+      "sqrl-cli-functions": ["../packages/sqrl-cli-functions"],
+      "sqrl-common": ["../packages/sqrl-common"],
+      "sqrl-jsonpath": ["../packages/sqrl-jsonpath"],
+      "sqrl-load-functions": ["../packages/sqrl-load-functions"],
+      "sqrl-redis-functions": ["../packages/sqrl-redis-functions"],
+      "sqrl-test-utils": ["../packages/sqrl-test-utils"],
+      "sqrl-text-functions": ["../packages/sqrl-text-functions"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "references": [


### PR DESCRIPTION
# Problem

Vercel isn’t building

# Solution

Update Vercel build settings to be monorepo-friendly, add a `paths` entry to websqrl’s tsconfig file to map each internal dep to the local version rather than what’s on NPM.

The “Build & Development Settings” section needs to be updated to look like this:

<img width="679" alt="Screenshot 2022-12-12 at 20 28 59" src="https://user-images.githubusercontent.com/13781/207204930-b031a61c-c167-476b-bc42-385f023d6d9f.png">

# Result

Vercel builds without issue: https://websqrl-i34h6h7l8-meyer.vercel.app/
