### PR TITLE
Clean up FeatureMap in API

### DIFF
--- a/packages/sqrl/src/api/execute.ts
+++ b/packages/sqrl/src/api/execute.ts
@@ -59,9 +59,8 @@ export interface ExecutableOptions {
   instance: Instance;
 }
 
-export type FeatureMap<T extends string = string> = {
-  // TODO(meyer) any --> unknown
-  [key in T]: any;
+export type FeatureMap<K extends string = string, V extends any = any> = {
+  [key in K]: V;
 };
 
 export interface FunctionInfo {


### PR DESCRIPTION
# Problem

`FeatureMap` is part of the API and should be cleaner.

# Solution

Cleaned it up a little more, added an optional value type

# Result

Just neater, noticed this snuck though. Need to be *extra* careful about changing the `api/` folder