### PR TITLE
Entity test

### DIFF
--- a/packages/sqrl-cli-functions/__tests__/source.spec.ts
+++ b/packages/sqrl-cli-functions/__tests__/source.spec.ts
@@ -38,7 +38,7 @@ test("saves features", async () => {
   await runSqrlTest(
     sourceTemplate`
     LET Result := 5;
-    ASSERT source(Result) = ${`
+    ASSERT featureSource(Result) = ${`
       function () {
         return bluebird.resolve(5);
       }
@@ -49,7 +49,7 @@ test("saves features", async () => {
     LET Z := 2;
     LET Result := (X * Y) / (Z - 1);
     # @NOTE: divide() is not pure for now as it deals with divide by zero
-    ASSERT source(Result) = ${`
+    ASSERT featureSource(Result) = ${`
       function () {
         return bluebird.resolve(functions._divide(this, 20, 1));
       }
@@ -64,8 +64,8 @@ test("saves features", async () => {
     LET Fast := delayMs(10, "Hello!");
     LET Choice1 := Slow OR Fast;
     LET Choice2 := Fast OR Slow;
-    ASSERT source(Choice1) = source(Choice2);
-    ASSERT source(Choice1) = ${`
+    ASSERT featureSource(Choice1) = featureSource(Choice2);
+    ASSERT featureSource(Choice1) = ${`
       function () {
         const f0 = () =>
           functions._orSequential(this, [
@@ -77,7 +77,7 @@ test("saves features", async () => {
     `};
 
     LET List := [Fast, Slow];
-    ASSERT source(List) = ${`
+    ASSERT featureSource(List) = ${`
       function () {
         return this.load(\"Fast\", \"Slow\");
       }

--- a/packages/sqrl-cli-functions/src/SourceFunctions.ts
+++ b/packages/sqrl-cli-functions/src/SourceFunctions.ts
@@ -26,14 +26,41 @@ export function registerSourceFunction(instance: Instance) {
     }
   );
 
+  instance.registerStatement(
+    "SqrlLogStatements",
+    async function printAllSource(state: Execution) {
+      state.getSourcePrinter().printAllSource();
+    },
+    {
+      args: [AT.state],
+      argstring: "",
+      docstring: "Prints the SQRL execution source",
+    }
+  );
+
   instance.registerSync(
-    function featureSource(state: Execution, featureName, props = {}) {
+    function _featureSource(state: Execution, featureName, props = {}) {
       return state.getSourcePrinter().getSourceForSlotName(featureName, props);
     },
     {
       args: [AT.state, AT.constant.string, AT.any.optional],
+    }
+  );
+
+  instance.registerTransform(
+    function featureSource(state: CompileState, ast: CallAst): Ast {
+      const arg = ast.args[0];
+      if (arg.type !== "feature") {
+        throw new Error("Expected feature arguments");
+      }
+      return AstBuilder.call("_featureSource", [
+        AstBuilder.constant(arg.value),
+      ]);
+    },
+    {
+      args: [AT.feature],
       argstring: "feature",
-      docstring: "Returns the source code for the given feature",
+      docstring: "Returns the JavaScript source of the given feature",
     }
   );
 
@@ -48,18 +75,6 @@ export function registerSourceFunction(instance: Instance) {
     }
   );
 
-  instance.registerStatement(
-    "SqrlLogStatements",
-    async function printAllSource(state: Execution) {
-      state.getSourcePrinter().printAllSource();
-    },
-    {
-      args: [AT.state],
-      argstring: "",
-      docstring: "Prints the SQRL execution source",
-    }
-  );
-
   instance.registerTransform(
     function printSource(state: CompileState, ast: CallAst): Ast {
       const arg = ast.args[0];
@@ -71,26 +86,7 @@ export function registerSourceFunction(instance: Instance) {
     {
       args: [AT.feature],
       argstring: "feature",
-      docstring: "Prints the SQRL source of the given feature",
-    }
-  );
-
-  instance.registerTransform(
-    function source(state: CompileState, ast: CallAst): Ast {
-      const feature = ast.args[0];
-      if (feature.type !== "feature") {
-        throw new Error("Expected feature argument");
-      }
-      return AstBuilder.call("featureSource", [
-        AstBuilder.constant(feature.value),
-        ...ast.args.slice(1),
-      ]);
-    },
-    {
-      args: [AT.feature, AT.any.optional],
-
-      argstring: "feature",
-      docstring: "Returns the source code of the given feature",
+      docstring: "Prints the JavaScript source of the given feature",
     }
   );
 }

--- a/packages/sqrl-cli/__tests__/doc-tests/entities.spec.ts
+++ b/packages/sqrl-cli/__tests__/doc-tests/entities.spec.ts
@@ -10,13 +10,26 @@ test("works", async () => {
     await runRepl(
       [],
       `
-    LET User := entity('User', '1234')
-    User='1234'
-    str(date(User))`
+      LET ActionData := {"name": "hi", "user_id": "1.2.3.4"};
+      LET ActionName := jsonValue(ActionData, "$.name")
+      LET UserId := jsonValue(ActionData, "$.user_id")
+      LET User := entity('User', UserId)
+      featureSource(User)
+      User="tom"
+      User="1.2.3.4"
+      str(date(User))
+      `
     )
   ).toEqual([
-    "'1234'",
-    "'2019-01-02T03:04:56.789Z'",
+    "{ name: 'hi', user_id: '1.2.3.4' }",
+    "'hi'",
+    "'1.2.3.4'",
+    "'1.2.3.4'",
+    "'function () {\\n' +\n  '  const f0 = () =>\\n' +\n  '    " +
+      'functions._entity(this, "User", this.slots["UserId"].value());\\n\' +\n  \'  ' +
+      "return this.load(\"UserId\").then(f0);\\n' +\n  '}'",
+    "false",
+    "true",
     "'2019-01-02T03:04:56.789Z'",
   ]);
 });

--- a/packages/sqrl-cli/src/repl/SqrlRepl.ts
+++ b/packages/sqrl-cli/src/repl/SqrlRepl.ts
@@ -37,7 +37,9 @@ export class SqrlRepl extends EventEmitter<EventTypes> {
   private historyPath: string = expandTilde("~/.sqrl_repl_history");
   private stdin: Readable;
   private stdout: Writable;
-  private busy = new Semaphore();
+  private busy = new Semaphore({
+    max: 1,
+  });
 
   constructor(
     private instance: Instance,
@@ -116,7 +118,7 @@ export class SqrlRepl extends EventEmitter<EventTypes> {
   }
 
   private async eval(cmd, context, filename) {
-    this.busy.increment();
+    await this.busy.increment();
     const ctx = this.traceFactory();
     try {
       appendFileSync(this.historyPath, cmd);


### PR DESCRIPTION
# Problem

Test was flakey, and didn't match the example in the documentation.

# Solution

Limit REPL execution to one line at a time (fixed ordering issue), and add some more content to the test to better match the documentation online (ensuring it stays working.)

Includes some cleanup to the source fetch/print functions. There was a lot of duplication and poor naming.

# Result

Should see less test failures