### PR TITLE
Use ResizeObserver in MonacoEditor component

### DIFF
--- a/websqrl/src/MonacoEditor.tsx
+++ b/websqrl/src/MonacoEditor.tsx
@@ -312,12 +312,17 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
 
     editorRef.current = editor;
 
-    // TODO(meyer) debounce this
-    const resizeHandler = () => {
-      editor.layout();
-    };
+    const resizeObserver = new ResizeObserver((entries) => {
+      const containerElement = entries.find(
+        (entry) => entry.target === containerRef.current
+      );
+      // container was resized
+      if (containerElement) {
+        editor.layout();
+      }
+    });
 
-    window.addEventListener("resize", resizeHandler);
+    resizeObserver.observe(containerRef.current);
 
     const onChangeModelContentSubscription = editor.onDidChangeModelContent(
       (event) => {
@@ -331,7 +336,7 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
       editor.dispose();
       model.dispose();
       onChangeModelContentSubscription.dispose();
-      window.removeEventListener("resize", resizeHandler);
+      resizeObserver.disconnect();
     };
   }, [monacoEditorObj.state, sqrlFunctions]);
 

--- a/websqrl/tsconfig.json
+++ b/websqrl/tsconfig.json
@@ -24,7 +24,8 @@
       "sqrl-redis-functions": ["../packages/sqrl-redis-functions"],
       "sqrl-test-utils": ["../packages/sqrl-test-utils"],
       "sqrl-text-functions": ["../packages/sqrl-text-functions"]
-    }
+    },
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "references": [


### PR DESCRIPTION
# Problem

MonacoEditor only recalculates its bounds when the browser window is resized. The container div might change size arbitrarily however, so we need to use something that reacts to the container size changes instead.

# Solution

Use a ResizeObserver

# Result

MonacoEditor resizes correctly when its container is resized.