### PR TITLE
Allow event processing cursor to be set in the UI

### DIFF
--- a/websqrl/components/BlueskyEventStory.tsx
+++ b/websqrl/components/BlueskyEventStory.tsx
@@ -4,11 +4,15 @@ import type { Result } from "../src/types";
 import { StoryResult } from "./StoryResult";
 
 export const BLUESKY_FETCH_FEATURES = [
-  "AuthorUsername",
-  "AuthorProfileImageUrl",
+  "Version",
+  "EventName",
+  "RecordType",
+  "AuthorId",
   "TweetText",
   "TweetId",
   "TweetDate",
+  "Subject",
+  "SubjectCid",
 ] as const;
 export type BlueskyFetchFeature = typeof BLUESKY_FETCH_FEATURES[number];
 
@@ -19,41 +23,62 @@ export const BlueskyEventStory: React.FC<BlueskyEventStoryProps> = ({
   result,
   logs,
 }) => {
-  const userUrl = `https://twitter.com/${features.AuthorUsername}`;
-  const tweetUrl = `https://twitter.com/${features.AuthorUsername}/status/${features.TweetId}`;
+  const userUrl = `https://bsky.app/profile/${features.AuthorId}`;
+
+  if (features.EventName === "create-post") {
+    return (
+      <Col gap={10}>
+        <Row gap={6}>
+          <a target="_blank" href={userUrl}>
+            Author: {features.AuthorId}
+          </a>
+          <Inline color={styleConstants.secondary}>
+            ({features.TweetDate})
+          </Inline>
+        </Row>
+
+        {features.TweetText && (
+          <Block
+            component="blockquote"
+            borderLeft="2px solid"
+            padding="4px 10px"
+            borderColor={styleConstants.secondary}
+          >
+            {features.TweetText}
+          </Block>
+        )}
+
+        <StoryResult result={result} logs={logs}></StoryResult>
+      </Col>
+    );
+  }
 
   return (
     <Col gap={10}>
+      <p>Event type: {features.EventName}</p>
       <Row gap={6}>
-        <Block
-          backgroundImage={`url("${features.AuthorProfileImageUrl}")`}
-          backgroundPosition="center center"
-          backgroundSize="contain"
-          height={40}
-          width={40}
-          borderRadius={4}
-        />
-
         <a target="_blank" href={userUrl}>
-          @{features.AuthorUsername}
+          Author: {features.AuthorId}
         </a>
-        <Inline color={styleConstants.secondary}>
-          (
-          <a href={tweetUrl} target="_blank">
-            {features.TweetDate}
-          </a>
-          )
-        </Inline>
+        <Inline color={styleConstants.secondary}>({features.TweetDate})</Inline>
       </Row>
 
-      <Block
-        component="blockquote"
-        borderLeft="2px solid"
-        padding="4px 10px"
-        borderColor={styleConstants.secondary}
-      >
-        {features.TweetText}
-      </Block>
+      {features.TweetText && (
+        <Block
+          component="blockquote"
+          borderLeft="2px solid"
+          padding="4px 10px"
+          borderColor={styleConstants.secondary}
+        >
+          {features.TweetText}
+        </Block>
+      )}
+
+      {features.SubjectCid ? (
+        <p>Subject CID: {features.SubjectCid}</p>
+      ) : features.Subject ? (
+        <p>Subject: {features.Subject}</p>
+      ) : null}
 
       <StoryResult result={result} logs={logs}></StoryResult>
     </Col>

--- a/websqrl/components/Playhead.tsx
+++ b/websqrl/components/Playhead.tsx
@@ -1,0 +1,104 @@
+import { Block } from "jsxstyle";
+import { useEffect, useRef, useState } from "react";
+import { getFileNameForDate } from "../src/getFileNameForDate";
+import { StatusResponse } from "../src/types";
+
+export type PlayheadSpeed = "realtime" | number;
+
+interface PlayheadProps {
+  speed: PlayheadSpeed;
+  status: Omit<StatusResponse, "type"> | undefined;
+  setSpeed: (speed: PlayheadSpeed) => void;
+  setTimestamp: (timestamp: number) => void;
+}
+
+const tenMinutePx = 200;
+const oneMinuteMs = 1000 * 60;
+const tenMinutesMs = 10 * oneMinuteMs;
+// give event processing a minute to upload latest data to S3
+const windowBuffer = 11 * oneMinuteMs;
+
+export const Playhead: React.FC<PlayheadProps> = ({ setTimestamp, status }) => {
+  const [playheadWidth, setPlayheadWidth] = useState<number>(0);
+  const playheadContainerElementRef = useRef<HTMLDivElement>(null);
+  const [now, setNow] = useState(new Date().valueOf());
+
+  useEffect(() => {
+    const nowTimer = setInterval(() => {
+      setNow(new Date().valueOf());
+    }, 5000);
+
+    return () => clearInterval(nowTimer);
+  });
+
+  useEffect(() => {
+    const ref = playheadContainerElementRef.current;
+    if (!ref) return;
+    const resizeObserver = new ResizeObserver((things) => {
+      for (const thing of things) {
+        if (thing.target !== ref) continue;
+        setPlayheadWidth(thing.contentRect.width);
+      }
+    });
+
+    resizeObserver.observe(ref);
+    return () => {
+      resizeObserver.unobserve(ref);
+      resizeObserver.disconnect();
+    };
+  }, [playheadContainerElementRef.current]);
+
+  const totalElements = Math.max(playheadWidth / tenMinutePx);
+  const playheadElements = Array.from({ length: totalElements }).map(
+    (_, index) => {
+      const windowDate = new Date(now - tenMinutesMs * index - windowBuffer);
+      windowDate.setMinutes(Math.floor(windowDate.getMinutes() / 10) * 10);
+      windowDate.setSeconds(0);
+      windowDate.setMilliseconds(0);
+      const key = getFileNameForDate(windowDate);
+
+      const isCurrentItem = status?.timestamp === key;
+
+      const progressElement = !isCurrentItem ? null : (
+        <Block>
+          {(status.currentIndex + 1).toLocaleString()} of{" "}
+          {status.total.toLocaleString()} events
+        </Block>
+      );
+
+      return (
+        <Block
+          component="button"
+          key={key}
+          position="absolute"
+          appearance="none"
+          WebkitAppearance="none"
+          border="none"
+          backgroundColor="none"
+          hoverBackgroundColor="none"
+          width={tenMinutePx}
+          borderBottom={status?.timestamp === key && "5px solid #888"}
+          top={0}
+          bottom={0}
+          right={tenMinutePx * index}
+          cursor="pointer"
+          onClick={() => setTimestamp(windowDate.valueOf())}
+        >
+          {windowDate.toLocaleTimeString()}
+          {progressElement}
+        </Block>
+      );
+    }
+  );
+
+  return (
+    <Block
+      height={50}
+      flex="0 0 auto"
+      position="relative"
+      props={{ ref: playheadContainerElementRef }}
+    >
+      {playheadElements}
+    </Block>
+  );
+};

--- a/websqrl/components/StoryResult.tsx
+++ b/websqrl/components/StoryResult.tsx
@@ -24,7 +24,7 @@ export const StoryResult: React.FC<{
 
   return (
     <>
-      {result.shown && (
+      {result.shown && result.shownCause && (
         <Block color={styleConstants.secondary}>
           <Block>Rules fired</Block>
           <Block component="ul" listStyle="inside">

--- a/websqrl/components/StreamPage.tsx
+++ b/websqrl/components/StreamPage.tsx
@@ -11,7 +11,7 @@ import { Playhead, PlayheadSpeed } from "./Playhead";
 const MAX_STORY_FEED_LENGTH = 30;
 
 interface StreamPageProps<T extends string> {
-  dateJsonPath: string;
+  dateFieldName: string;
   fetchFeatures: readonly T[];
   sampleCode: string;
   storyComponent: React.FC<Result<T>>;
@@ -68,7 +68,7 @@ const statusReducer: React.Reducer<
 };
 
 export function StreamPage<T extends string>({
-  dateJsonPath,
+  dateFieldName,
   fetchFeatures,
   sampleCode,
   storyComponent: StoryComponent,
@@ -122,7 +122,7 @@ export function StreamPage<T extends string>({
     req({
       type: "init",
       source,
-      dateJsonPath,
+      dateFieldName: dateFieldName,
       fetchFeatures,
       speed: playheadSpeed,
       cursor: startDate,

--- a/websqrl/next.config.js
+++ b/websqrl/next.config.js
@@ -3,8 +3,12 @@
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const assert = require("assert");
 
+/** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  env: {
+    BLUESKY_MOCK_API: process.env.BLUESKY_MOCK_API === "true",
+  },
   webpack: (
     /** @type {import('webpack').Configuration} */
     config,

--- a/websqrl/pages/api/bluesky-dev/[jsonFilename].ts
+++ b/websqrl/pages/api/bluesky-dev/[jsonFilename].ts
@@ -1,0 +1,125 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getFileNameForDate } from "../../../src/getFileNameForDate";
+import { invariant } from "../../../src/invariant";
+
+const getSampleData = (date: Date) => {
+  const datePlusSeconds = (seconds: number) => {
+    const newDate = new Date(date);
+    newDate.setSeconds(newDate.getSeconds() + seconds);
+    return newDate.toISOString();
+  };
+
+  const timestampString = getFileNameForDate(date);
+
+  return {
+    v: 0,
+    timestamp: timestampString,
+    events: [
+      {
+        v: 1,
+        eventName: "create-follow",
+        timestamp: datePlusSeconds(0),
+        payload: {
+          record: {
+            $type: "app.bsky.graph.follow",
+            subject: "did:plc:uuuuuuuuuuuuuuu",
+            createdAt: datePlusSeconds(0),
+          },
+          uri: "at://did:plc:aaaaaaaaa/app.bsky.graph.follow/bbbbbbbbbb",
+          cid: "cccccccccccccc",
+          author: "did:plc:aaaaaaaaa",
+        },
+        resolvedDids: {
+          "did:plc:aaaaaaaaa": "example1.bsky.social",
+        },
+      },
+      {
+        v: 1,
+        eventName: "create-like",
+        timestamp: datePlusSeconds(5),
+        payload: {
+          record: {
+            $type: "app.bsky.feed.like",
+            subject: {
+              cid: "dddddddddddddd",
+              uri: "at://did:plc:eeeeeeeeeeeee/app.bsky.feed.post/hhhhhhhhhhhhh",
+            },
+            createdAt: datePlusSeconds(5),
+          },
+          uri: "at://did:plc:iiiiiiiiiiiiiiiiii/app.bsky.feed.like/jjjjjjjjjjjjjjjjj",
+          cid: "kkkkkkkkkkkkkkkkk",
+          author: "did:plc:iiiiiiiiiiiiiiiiii",
+        },
+        resolvedDids: {
+          "did:plc:eeeeeeeeeeeee": "example2.bsky.social",
+          "did:plc:iiiiiiiiiiiiiiiiii": "example3.bsky.social",
+        },
+      },
+      {
+        v: 1,
+        eventName: "create-post",
+        timestamp: datePlusSeconds(10),
+        payload: {
+          record: {
+            text: "The text of your post " + timestampString,
+            $type: "app.bsky.feed.post",
+            reply: {
+              root: {
+                cid: "llllllllllllllllllll",
+                uri: "at://did:plc:mmmmmmmmmmmmmmmmm/app.bsky.feed.post/nnnnnnnnnnnnn",
+              },
+              parent: {
+                cid: "llllllllllllllllllll",
+                uri: "at://did:plc:mmmmmmmmmmmmmmmmm/app.bsky.feed.post/nnnnnnnnnnnnn",
+              },
+            },
+            createdAt: datePlusSeconds(10),
+          },
+          uri: "at://did:plc:oooooooooooooooooo/app.bsky.feed.post/ppppppppppppppppp",
+          cid: "qqqqqqqqqqqqqqqqqqqqqqq",
+          author: "did:plc:oooooooooooooooooo",
+        },
+        resolvedDids: { "did:plc:oooooooooooooooooo": "example4.bsky.social" },
+      },
+      {
+        v: 1,
+        eventName: "delete-like",
+        timestamp: datePlusSeconds(15),
+        payload: {
+          uri: "at://did:plc:rrrrrrrrrrrrrrrrrrrrr/app.bsky.feed.like/ssssssssssssssss",
+        },
+        resolvedDids: {
+          "did:plc:rrrrrrrrrrrrrrrrrrrrr": "example5.bsky.social",
+        },
+      },
+    ],
+  };
+};
+
+export default function blueskyMockApiHandler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (!process.env.BLUESKY_MOCK_API) {
+    return res.status(404);
+  }
+
+  const { jsonFilename } = req.query;
+  invariant(typeof jsonFilename === "string", "Expected a string");
+  invariant(
+    jsonFilename.endsWith(".json"),
+    "Expected a path ending in `.json`"
+  );
+  const thing = jsonFilename.slice(0, -".json".length);
+  const date = new Date(thing + "0:00.000Z");
+  const latestDate = new Date();
+  latestDate.setMinutes(latestDate.getMinutes() - 11);
+
+  console.log("Fetch data for %o (%s)", date, date.toLocaleString());
+
+  // simulate prod data delay
+  if (date > latestDate)
+    return res.status(404).send("The requested date is too far in the future");
+
+  res.json(getSampleData(date));
+}

--- a/websqrl/pages/bluesky.tsx
+++ b/websqrl/pages/bluesky.tsx
@@ -15,12 +15,15 @@ export default function TwitterPage() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <StreamPage
-        urlPrefix="https://sqrl-twitter-stream.s3.amazonaws.com/v1/"
-        extractDate={(payload) => new Date(payload.dt)}
+        dateJsonPath="timestamp"
+        urlPrefix={
+          process.env.BLUESKY_MOCK_API
+            ? "/api/bluesky-dev/"
+            : "https://sqrl-bluesky-demo.s3.amazonaws.com/prod/v0/"
+        }
         sampleCode={sampleCode}
         storyComponent={BlueskyEventStory}
         fetchFeatures={BLUESKY_FETCH_FEATURES}
-        startDateISO={"2023-02-07T09:00Z"}
         shouldLogResult={(result) => result.result.shown}
       >
         This demonstration is running on the

--- a/websqrl/pages/bluesky.tsx
+++ b/websqrl/pages/bluesky.tsx
@@ -15,7 +15,7 @@ export default function TwitterPage() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <StreamPage
-        dateJsonPath="timestamp"
+        dateFieldName="timestamp"
         urlPrefix={
           process.env.BLUESKY_MOCK_API
             ? "/api/bluesky-dev/"

--- a/websqrl/src/EventDomain.ts
+++ b/websqrl/src/EventDomain.ts
@@ -1,12 +1,11 @@
 import { getFileNameForDate } from "./getFileNameForDate";
 import type { EventData } from "./types";
 
-// TODO(meyer) actual jsonpath stuff
-const getDateFromJsonPath = (
+const getDateFromEventObject = (
   event: Record<string, unknown>,
-  jsonPath: string
+  fieldName: string
 ): Date => {
-  const value = event[jsonPath];
+  const value = event[fieldName];
   if (typeof value === "string" || typeof value === "number") {
     return new Date(value);
   }
@@ -18,16 +17,16 @@ export interface EventDomainOptions {
   urlPrefix: string;
   /** The date that event processing begins. This value will be rounded to the nearest ten minute interval. */
   cursor: Date;
-  /** JSONPath to the date value in the event object */
-  dateJsonPath: string;
+  /** Name of the date field in the event object */
+  dateFieldName: string;
   /** Event processing speed in milliseconds. Specify "realtime" if you'd like events to be processed in... _realtime_. */
   speed: number | "realtime";
 }
 
 export class EventDomain {
-  constructor({ urlPrefix, cursor, dateJsonPath, speed }: EventDomainOptions) {
+  constructor({ urlPrefix, cursor, dateFieldName, speed }: EventDomainOptions) {
     this.cursor = cursor;
-    this.dateJsonPath = dateJsonPath;
+    this.dateFieldName = dateFieldName;
     this.speed = speed;
     this.urlPrefix = urlPrefix;
     this.dataPromise = this.fetchData();
@@ -35,7 +34,7 @@ export class EventDomain {
 
   // user-configurable options
   private cursor: Date;
-  private dateJsonPath: string;
+  private dateFieldName: string;
   private speed: number | "realtime";
   private urlPrefix: string;
 
@@ -105,8 +104,8 @@ export class EventDomain {
         // calculate the number of milliseconds between event timestamps
         // TODO(meyer) probably just easier to divide 10 minutes by event count
         eventDelay = Math.max(
-          getDateFromJsonPath(currentEvent, this.dateJsonPath).valueOf() -
-            getDateFromJsonPath(previousEvent, this.dateJsonPath).valueOf(),
+          getDateFromEventObject(currentEvent, this.dateFieldName).valueOf() -
+            getDateFromEventObject(previousEvent, this.dateFieldName).valueOf(),
           0
         );
       } else {

--- a/websqrl/src/EventDomain.ts
+++ b/websqrl/src/EventDomain.ts
@@ -1,0 +1,145 @@
+import { getFileNameForDate } from "./getFileNameForDate";
+import type { EventData } from "./types";
+
+// TODO(meyer) actual jsonpath stuff
+const getDateFromJsonPath = (
+  event: Record<string, unknown>,
+  jsonPath: string
+): Date => {
+  const value = event[jsonPath];
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  throw new Error("Invalid date JSONPath value");
+};
+
+export interface EventDomainOptions {
+  /** Prefix for URLs containing event data */
+  urlPrefix: string;
+  /** The date that event processing begins. This value will be rounded to the nearest ten minute interval. */
+  cursor: Date;
+  /** JSONPath to the date value in the event object */
+  dateJsonPath: string;
+  /** Event processing speed in milliseconds. Specify "realtime" if you'd like events to be processed in... _realtime_. */
+  speed: number | "realtime";
+}
+
+export class EventDomain {
+  constructor({ urlPrefix, cursor, dateJsonPath, speed }: EventDomainOptions) {
+    this.cursor = cursor;
+    this.dateJsonPath = dateJsonPath;
+    this.speed = speed;
+    this.urlPrefix = urlPrefix;
+    this.dataPromise = this.fetchData();
+  }
+
+  // user-configurable options
+  private cursor: Date;
+  private dateJsonPath: string;
+  private speed: number | "realtime";
+  private urlPrefix: string;
+
+  private events: EventData[] = [];
+  private eventIndex = 0;
+
+  private dataPromise: Promise<void> | null = null;
+
+  public setCursor(newDate: Date) {
+    const oldFileName = getFileNameForDate(this.cursor);
+    const newFileName = getFileNameForDate(newDate);
+    if (oldFileName !== newFileName) {
+      this.cursor = newDate;
+      this.dataPromise = this.fetchData();
+    }
+  }
+
+  public async fetchData() {
+    const filename = getFileNameForDate(this.cursor);
+
+    const jsonUrl = `${this.urlPrefix}${filename}.json`;
+    const result = await fetch(jsonUrl);
+    if (result.status !== 200) {
+      throw new Error(
+        "Non-200 status: " + result.status + ". " + result.statusText
+      );
+    }
+    const resultJson = await result.json();
+    if (!Array.isArray(resultJson.events)) {
+      throw new Error("expected an array");
+    }
+    this.eventIndex = 0;
+    this.events = resultJson.events;
+  }
+
+  async getNextEventDelay(): Promise<number> {
+    let eventDelay: number;
+    // ensure we have fetched event data
+    await this.dataPromise;
+    const metadata: Record<string, any> = { speed: this.speed };
+    if (this.eventIndex === 0) {
+      metadata.isFirstItem = true;
+      eventDelay = 0;
+    } else {
+      const previousEvent = this.events[this.eventIndex - 1];
+      const currentEvent = this.events[this.eventIndex];
+
+      if (this.eventIndex >= this.events.length) {
+        metadata.isLastItem = true;
+        const maxTime = new Date();
+        // 11 minute offset = 10 minutes for the window + 1 minute for some extra forgiveness
+        maxTime.setMinutes(maxTime.getMinutes() - 11);
+
+        const updatedWindowDate = new Date(this.cursor);
+        updatedWindowDate.setMinutes(this.cursor.getMinutes() + 10);
+        if (updatedWindowDate > maxTime) {
+          metadata.updateWindowExceeded = true;
+          eventDelay = updatedWindowDate.valueOf() - maxTime.valueOf();
+        } else {
+          metadata.updateWindowExceeded = false;
+          // immediately fetch the next batch
+          // TODO(meyer) use `this.speed` here
+          eventDelay = 0;
+        }
+      } else if (this.speed === "realtime") {
+        metadata.isRealtime = true;
+        // calculate the number of milliseconds between event timestamps
+        // TODO(meyer) probably just easier to divide 10 minutes by event count
+        eventDelay = Math.max(
+          getDateFromJsonPath(currentEvent, this.dateJsonPath).valueOf() -
+            getDateFromJsonPath(previousEvent, this.dateJsonPath).valueOf(),
+          0
+        );
+      } else {
+        metadata.fallback = true;
+        eventDelay = this.speed;
+      }
+    }
+    return eventDelay;
+  }
+
+  async processNextEvent<T>(
+    processFn: (event: EventData) => Promise<T>
+  ): Promise<T> {
+    if (this.eventIndex >= this.events.length) {
+      const maxTime = new Date();
+      // 11 minute offset = 10 minutes for the window + 1 minute for some extra forgiveness
+      maxTime.setMinutes(maxTime.getMinutes() - 11);
+      this.cursor.setMinutes(this.cursor.getMinutes() + 10);
+      if (this.cursor > maxTime) {
+        // TODO(meyer) sleep for this many milliseconds? hmmm...
+        throw Error(
+          "Cannot fetch more events, please wait " +
+            (this.cursor.valueOf() - maxTime.valueOf()) / 1000 +
+            " more seconds"
+        );
+      }
+      this.dataPromise = this.fetchData();
+    }
+
+    await this.dataPromise;
+    const event = this.events[this.eventIndex];
+    const result = await processFn(event);
+    this.eventIndex++;
+    return result;
+  }
+}

--- a/websqrl/src/MonacoEditor.tsx
+++ b/websqrl/src/MonacoEditor.tsx
@@ -317,7 +317,6 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
         enabled: true,
       },
       ...options,
-      extraEditorClassName: className,
       language: "sqrl",
       model,
       theme,
@@ -353,5 +352,5 @@ export const MonacoEditor: React.FC<MonacoEditorProps> = ({
     };
   }, [monacoEditorObj.state, sqrlFunctions, containerRef.current]);
 
-  return <div style={style} ref={containerRef} />;
+  return <div style={style} className={className} ref={containerRef} />;
 };

--- a/websqrl/src/bluesky-sample.sqrl
+++ b/websqrl/src/bluesky-sample.sqrl
@@ -14,16 +14,16 @@ LET DatasetId := 1;
 LET ProfanityFilterEnabled := false;
 
 # Feature extraction from the Twitter data
-LET TweetText := jsonValue(EventData, '$.data.text');
-LET AuthorId := jsonValue(EventData, '$.data.author_id');
-LET TweetId := jsonValue(EventData, '$.data.id');
-LET TweetDate := jsonValue(EventData, '$.data.created_at');
-LET Users := jsonValue(EventData, '$.includes.users');
-LET AuthorUserData := first([It for It in Users where jsonValue(It, "$.id") = AuthorId]);
-LET AuthorUsername := entity("User", jsonValue(AuthorUserData, "$.username"));
-LET AuthorCreatedAt := jsonValue(AuthorUserData, "$.created_at");
-LET AuthorName := jsonValue(AuthorUserData, "$.name");
-LET AuthorProfileImageUrl := jsonValue(AuthorUserData, "$.profile_image_url");
+LET Version := jsonValue(EventData, '$.v');
+LET EventName := jsonValue(EventData, '$.eventName');
+LET RecordType := jsonValue(EventData, '$.payload.record.$type');
+LET AuthorId := jsonValue(EventData, '$.payload.author');
+LET TweetText := jsonValue(EventData, '$.payload.record.text');
+LET TweetId := jsonValue(EventData, '$.payload.cid');
+# TODO(meyer) payload.record.createdAt is not available on all events
+LET TweetDate := jsonValue(EventData, '$.timestamp');
+LET SubjectCid := jsonValue(EventData, '$.payload.record.subject.cid');
+LET Subject := jsonValue(EventData, '$.payload.record.subject');
 
 # These features follow a standard naming scheme, and allow rules to be shared between
 # multiple websites, in our case the Wikipedia and Twitter demos.
@@ -36,14 +36,14 @@ LET TextSimhash := simhash(UserGeneratedContent);
 # Easily defining counters like this is one of the powers of SQRL. These counters
 # will automatically start at 0 when a new one is created. This requires a bit of
 # forethought, but as long as rules deal with `greater than X` it works.
-LET TweetsByUser := count(BY AuthorUsername TOTAL);
+LET TweetsByUser := count(BY AuthorId, EventName TOTAL);
 LET CountBySimhash := count(BY TextSimhash LAST 5 MINUTES);
-LET UsersBySimhash := countUnique(AuthorUsername BY TextSimhash LAST 5 MINUTES);
+LET UsersBySimhash := countUnique(AuthorId BY TextSimhash LAST 5 MINUTES);
 
 # Simple rule to make sure atleast one tweet shows up in the UI
 LET IsFirstTweetSeen := NOT rateLimited(BY DatasetId MAX 1 EVERY YEARS);
 CREATE RULE FirstTweetSeen WHERE IsFirstTweetSeen WITH REASON
-    "This is not a bad thing, just flagging this first tweet scene so there is output here. If you want more content you can turn on the profanity filter.";
+    "This is not a bad thing, just flagging this first tweet seen so there is output here. If you want more content you can turn on the profanity filter.";
 
 # Simple rules for too much similar text
 CREATE RULE SimilarTweetText WHERE CountBySimhash>2 WITH REASON
@@ -57,22 +57,14 @@ LET BadWordMatches := patternMatches("bad-words.txt", UserGeneratedContent);
 CREATE RULE UsedBadWords WHERE ProfanityFilterEnabled AND BadWordMatches WITH REASON
     "Matched simple profanity filter: ${BadWordMatches}";
 
-# Look out for impersonated users
-# [NOTE] A rule like this would be a lot more advanced in production.
-# We let used to use a `deconfuse()` function that dealt with similar looking
-# unicode characters. See https://util.unicode.org/UnicodeJsps/confusables.jsp
-LET LooksLikeOlMusky := regexMatch("^E[1lI][0o]n.+Mu[$s]k.*$", AuthorName);
-CREATE RULE ImpersonatedMusk WHERE LooksLikeOlMusky AND AuthorUsername != "elonmusk";
-
 # This defines what gets shown in the sidebar
 # At Twitter this might mean deleted tweets, suspending users, etc.
 WHEN
     SimilarTweetText,
     SameTweetMultipleUsers,
     FirstTweetSeen,
-    UsedBadWords,
-    ImpersonatedMusk
+    UsedBadWords
 THEN showEvent();
 
 # Add some additional features if they are interesting
-log("Seen %d tweets by user", TweetsByUser) WHERE TweetsByUser>1;
+log("Seen", TweetsByUser, EventName, "by user") WHERE TweetsByUser>1;

--- a/websqrl/src/getFileNameForDate.ts
+++ b/websqrl/src/getFileNameForDate.ts
@@ -1,0 +1,3 @@
+export const getFileNameForDate = (date: Date) => {
+  return date.toISOString().substring(0, "0000-00-00T00:0".length);
+};

--- a/websqrl/src/types.ts
+++ b/websqrl/src/types.ts
@@ -1,5 +1,6 @@
 import { FeatureMap, FunctionInfo } from "sqrl";
 import { WebSQRLResult } from "../TweetManipulator";
+import type { EventDomainOptions } from "./EventDomain";
 
 export interface EventData {
   [key: string]: any;
@@ -9,12 +10,28 @@ export interface CompileRequest {
   type: "compile";
   source: string;
 }
-export interface EventRequest<T extends string> {
-  type: "event";
-  event: EventData;
-  requestFeatures: readonly T[];
+
+export interface InitRequest<T extends string> extends EventDomainOptions {
+  type: "init";
+  source: string;
+  fetchFeatures: readonly T[];
 }
-export type Request<T extends string> = CompileRequest | EventRequest<T>;
+
+export interface ConfigureRequest<T extends string>
+  extends Omit<InitRequest<T>, "type" | "urlPrefix"> {
+  type: "configure";
+}
+
+export interface PlayheadRequest {
+  type: "playhead";
+  position: Date;
+}
+
+export type Request<T extends string> =
+  | CompileRequest
+  | InitRequest<T>
+  | ConfigureRequest<T>
+  | PlayheadRequest;
 
 export interface SqrlInit {
   type: "sqrlInit";
@@ -39,14 +56,17 @@ export interface CompileError {
   source: string;
   location: Record<"start" | "end", Location> | undefined;
 }
+
 export interface RuntimeError {
   type: "runtimeError";
   message: string;
   source: string;
 }
+
 export interface LogEntry {
   args: any[];
 }
+
 export interface Result<T extends string> {
   type: "result";
   logs: Array<LogEntry>;
@@ -54,13 +74,18 @@ export interface Result<T extends string> {
   features: FeatureMap<T>;
   source: string;
 }
-export interface Render {
-  type: "render";
-  buffer: Uint8Array;
+
+export interface StatusResponse {
+  type: "status";
+  currentIndex: number;
+  total: number;
+  timestamp: string;
 }
+
 export type Response<T extends string> =
   | SqrlInit
   | CompileOkay
   | CompileError
   | RuntimeError
+  | StatusResponse
   | Result<T>;


### PR DESCRIPTION
# Problem

1. websqrl only operates on current event streams
2. bluesky demo rules haven't been updated

# Solution

I added a new very much work-in-progress cursor selector UI element to the bottom of the screen. It shows the current selected cursor and shows event processing progress. Check out the attached GIF for the general idea.

I moved event downloading to the web worker. The UI is only responsible for setting the "playhead" aka selected point where event processing should begin. You'll eventually be able to select playback speed to either "realtime" or some arbitrary millisecond value but for now it's processing events as fast as possible (i.e. next tick).

There's a new file, EventDomain, that handles all event-related state in the worker. It's got a few interesting methods:
- `setCursor`: set the date where event processing should begin
- `getNextEventDelay`: get the number of milliseconds to wait before processing the next event
- `processNextEvent`: do the thing

Once all the events for the current cursor have been processed, EventDomain increments the cursor by 10 minutes and then carries on. If the cursor is less than 11 minutes in the future, `getNextEventDelay` returns the number of milliseconds to wait until more data can be fetched.

The path to the date in each event object is now specified via fake jsonpath. I'm not sold on it but it's the only alternative I could think of to letting each demo set its own "getDate" function (can't serialise a function and i don't want to bake demo-specific stuff into the web worker).

none of the names for any of these things are final, feel free to rename things as you please. naming things is hard.

I also added a mock, dev-only Bluesky API so I could test event processing locally without having to wait for 10K events to go by.

# Result

Bluesky demo works now. There are still some bugs, most notably with cursor incrementing when enough time has progressed. I'll be looking into these bugs next.

![event processing example](https://github.com/sqrl-lang/sqrl/assets/13781/a8b0d265-678c-4423-a7e0-fa9cd544807d)



